### PR TITLE
21 add support for sri

### DIFF
--- a/gocwebtemplate-core/gocwebtemplate-core-base/src/main/java/goc/webtemplate/component/AbstractCoreBean.java
+++ b/gocwebtemplate-core/gocwebtemplate-core-base/src/main/java/goc/webtemplate/component/AbstractCoreBean.java
@@ -340,7 +340,7 @@ public abstract class AbstractCoreBean {
 
         templateVersion = this.getTemplateVersion();
         envRun = "";
-        if (Utility.isNullOrEmpty(templateVersion)) {
+        if (Utility.isNullOrEmpty(templateVersion) || templateVersion.equals("rn")) {
             if ((environment != null) && environment.isVersionRnCombined()) {
                 templateVersion = "rn/";
                 //(envRun stays blank)

--- a/gocwebtemplate-core/gocwebtemplate-core-base/src/main/java/goc/webtemplate/component/jsonentities/CDTSEnvironment.java
+++ b/gocwebtemplate-core/gocwebtemplate-core-base/src/main/java/goc/webtemplate/component/jsonentities/CDTSEnvironment.java
@@ -2,36 +2,34 @@ package goc.webtemplate.component.jsonentities;
 
 import java.io.Serializable;
 
-import java.util.ArrayList;
-
 /**
  * Holds information/configuration related to a CDTS environment
- * (mostly for the CDTSEnvironment.json file). 
+ * (mostly for the CDTSEnvironment.json file).
  */
 public class CDTSEnvironment implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private String  name;
-    
+
     private String  path;
     private String  localPath;
-    
+
     private String  theme;
     private String  subTheme;
-    private String  cdn; 
-    
+    private String  cdn;
+
     private boolean isVersionRnCombined;
     private boolean isEncryptionModifiable;
     private String  appendToTitle;
-    
+
     private int 	footerSectionLimit;
     private boolean	canHaveMultipleContactLinks;
     private boolean	canHaveContactLinkInAppTemplate;
     private boolean canUseWebAnalytics;
-    
+
     public CDTSEnvironment() {
     }
-    
+
     public String getName() {
         return name;
     }
@@ -75,11 +73,11 @@ public class CDTSEnvironment implements Serializable {
     public String getCDN() {
         return this.cdn;
     }
-    
+
     public void setCDN(String value) {
         this.cdn = value;
     }
-    
+
     public boolean isVersionRnCombined() {
         return isVersionRnCombined;
     }
@@ -99,7 +97,7 @@ public class CDTSEnvironment implements Serializable {
     public String getAppendToTitle() {
         return this.appendToTitle;
     }
-    
+
     public void setAppendToTitle(String value) {
         this.appendToTitle = value;
     }
@@ -127,31 +125,12 @@ public class CDTSEnvironment implements Serializable {
     public void setCanHaveContactLinkInAppTemplate(boolean canHaveContactLinkInAppTemplate) {
         this.canHaveContactLinkInAppTemplate = canHaveContactLinkInAppTemplate;
     }
-    
+
     public boolean getCanUseWebAnalytics() {
         return this.canUseWebAnalytics;
     }
-    
+
     public void setCanUseWebAnalytics(boolean canUseWebAnalytics) {
         this.canUseWebAnalytics = canUseWebAnalytics;
-    }
-
-	/**
-     * Exists as a container of CDTSEnvironment matching the format of the
-     * JSON file the data is read from.
-     */
-    public static class CDTSEnvironmentList {
-        private ArrayList<CDTSEnvironment>  environments;
-        
-        public CDTSEnvironmentList() {
-        }
-        
-        public ArrayList<CDTSEnvironment> getEnvironments() {
-            return this.environments;
-        }
-        
-        public void setEnvironments(ArrayList<CDTSEnvironment> value) {
-            this.environments = value;
-        }
     }
 }

--- a/gocwebtemplate-core/gocwebtemplate-core-base/src/main/java/goc/webtemplate/component/jsonentities/CDTSEnvironmentList.java
+++ b/gocwebtemplate-core/gocwebtemplate-core-base/src/main/java/goc/webtemplate/component/jsonentities/CDTSEnvironmentList.java
@@ -1,0 +1,43 @@
+package goc.webtemplate.component.jsonentities;
+
+import java.io.Serializable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+/**
+ * A container of CDTSEnvironment matching the format of the
+ * JSON file the data is read from.
+ */
+public class CDTSEnvironmentList implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private ArrayList<CDTSEnvironment>  environments;
+
+    /**
+     * Map of theme/version -> fileName -> sriHash
+     *
+     * This deeply nested HashMap of HashMap of HashMap is to avoid creating custom
+     * classes for each level of nesting.
+     */
+    private HashMap<String, HashMap<String, String>> themeSRIHashes;
+
+    public CDTSEnvironmentList() {
+    }
+
+    public ArrayList<CDTSEnvironment> getEnvironments() {
+        return this.environments;
+    }
+
+    public void setEnvironments(ArrayList<CDTSEnvironment> value) {
+        this.environments = value;
+    }
+
+    public HashMap<String, HashMap<String, String>> getThemeSRIHashes() {
+        return this.themeSRIHashes;
+    }
+
+    public void setThemeSRIHashes(HashMap<String, HashMap<String, String>> value) {
+        this.themeSRIHashes = value;
+    }
+}

--- a/gocwebtemplate-core/gocwebtemplate-core-base/src/main/java/goc/webtemplate/component/jsonentities/SetupBase.java
+++ b/gocwebtemplate-core/gocwebtemplate-core-base/src/main/java/goc/webtemplate/component/jsonentities/SetupBase.java
@@ -20,20 +20,22 @@ public class SetupBase implements Serializable {
     private String jqueryEnv;
     private ExitSecureSite exitSecureSite;
     private List<WebAnalyticsInfo> webAnalytics;
+    private Boolean sriEnabled;
 
     public SetupBase() {
     }
 
     public SetupBase(String subTheme, String jqueryEnv, ExitSecureSite exitSecureSite,
-            List<WebAnalyticsInfo> webAnalytics) {
+            List<WebAnalyticsInfo> webAnalytics, Boolean sriEnabled) {
         this.subTheme = subTheme;
         this.jqueryEnv = jqueryEnv;
         this.exitSecureSite = exitSecureSite;
         this.webAnalytics = webAnalytics;
+        this.sriEnabled = sriEnabled;
     }
 
     public SetupBase(String subTheme, String jqueryEnv, LeavingSecureSiteWarning lssw,
-            List<WebAnalyticsInfo> webAnalytics) {
+            List<WebAnalyticsInfo> webAnalytics, Boolean sriEnabled) {
         this.subTheme = subTheme;
         this.jqueryEnv = jqueryEnv;
         this.exitSecureSite = null;
@@ -41,6 +43,7 @@ public class SetupBase implements Serializable {
             this.exitSecureSite = new ExitSecureSite(lssw);
         }
         this.webAnalytics = webAnalytics;
+        this.sriEnabled = sriEnabled;
     }
 
     public String getSubTheme() {
@@ -73,5 +76,13 @@ public class SetupBase implements Serializable {
 
     public void setWebAnalytics(List<WebAnalyticsInfo> webAnalytics) {
         this.webAnalytics = webAnalytics;
+    }
+
+    public Boolean isSriEnabled() {
+        return sriEnabled;
+    }
+
+    public void setSriEnabled(Boolean sriEnabled) {
+        this.sriEnabled = sriEnabled;
     }
 }

--- a/gocwebtemplate-core/gocwebtemplate-core-base/src/main/resources/goc/webtemplate/global/config/CDTSEnvironments.json
+++ b/gocwebtemplate-core/gocwebtemplate-core-base/src/main/resources/goc/webtemplate/global/config/CDTSEnvironments.json
@@ -71,90 +71,11 @@
       "canHaveMultipleContactLinks": true,
       "canHaveContactLinkInAppTemplate": false,
       "canUseWebAnalytics": false
-    },
-    {
-      "name": "ESDC_GCINTRANET_SADE",
-      "path": "http{0}://s2tst-cdn-canada.sade-edap.prv/{1}/cls/wet/{2}/{3}cdts/",
-      "theme": "gcintranet",
-      "subTheme": "",
-      "cdn": "esdcnonprod",
-      "isVersionRnCombined": false,
-      "isEncryptionModifiable": true,
-      "appendToTitle": "",
-      "footerSectionLimit": 3,
-      "canHaveMultipleContactLinks": true,
-      "canHaveContactLinkInAppTemplate": false,
-      "canUseWebAnalytics": false
-    },
-    {
-      "name": "ESDC_GCINTRANET_QA",
-      "path": "http{0}://cdn-canada.services.gc.qat/{1}/cls/wet/{2}/{3}cdts/",
-      "theme": "gcintranet",
-      "subTheme": "",
-      "cdn": "esdcqat",
-      "isVersionRnCombined": false,
-      "isEncryptionModifiable": true,
-      "appendToTitle": "",
-      "footerSectionLimit": 3,
-      "canHaveMultipleContactLinks": true,
-      "canHaveContactLinkInAppTemplate": false,
-      "canUseWebAnalytics": false
-    },
-    {
-      "name": "ESDC_GCINTRANET_ESDCSUB_SADE",
-      "path": "http{0}://s2tst-cdn-canada.sade-edap.prv/{1}/cls/wet/{2}/{3}cdts/",
-      "theme": "gcintranet",
-      "subTheme": "esdc",
-      "cdn": "esdcnonprod",
-      "isVersionRnCombined": false,
-      "isEncryptionModifiable": true,
-      "appendToTitle": "",
-      "footerSectionLimit": 3,
-      "canHaveMultipleContactLinks": true,
-      "canHaveContactLinkInAppTemplate": false,
-      "canUseWebAnalytics": false
-    },
-    {
-      "name": "ESDC_GCINTRANET_ESDCSUB_QA",
-      "path": "http{0}://cdn-canada.services.gc.qat/{1}/cls/wet/{2}/{3}cdts/",
-      "theme": "gcintranet",
-      "subTheme": "esdc",
-      "cdn": "esdcqat",
-      "isVersionRnCombined": false,
-      "isEncryptionModifiable": true,
-      "appendToTitle": "",
-      "footerSectionLimit": 3,
-      "canHaveMultipleContactLinks": true,
-      "canHaveContactLinkInAppTemplate": false,
-      "canUseWebAnalytics": false
-    },
-    {
-      "name": "ESDC_GCWEB_SADE",
-      "path": "http{0}://s2tst-cdn-canada.sade-edap.prv/{1}/cls/wet/{2}/{3}cdts/",
-      "theme": "gcweb",
-      "subTheme": "",
-      "cdn": "esdcnonprod",
-      "isVersionRnCombined": false,
-      "isEncryptionModifiable": true,
-      "appendToTitle": " - Canada.ca",
-      "footerSectionLimit": 0,
-      "canHaveMultipleContactLinks": false,
-      "canHaveContactLinkInAppTemplate": true,
-      "canUseWebAnalytics": true
-    },
-    {
-      "name": "ESDC_GCWEB_QA",
-      "path": "http{0}://cdn-canada.services.gc.qat/{1}/cls/wet/{2}/{3}cdts/",
-      "theme": "gcweb",
-      "subTheme": "",
-      "cdn": "esdcqat",
-      "isVersionRnCombined": false,
-      "isEncryptionModifiable": true,
-      "appendToTitle": " - Canada.ca",
-      "footerSectionLimit": 0,
-      "canHaveMultipleContactLinks": false,
-      "canHaveContactLinkInAppTemplate": true,
-      "canUseWebAnalytics": true
     }
-  ]
+  ],
+  "//sri": "To add SRI hashes, create entries with key '<theme>/<version>' and value from the corresponding CDTS SRI-INFO.json file",
+  "themeSRIHashes" :{
+    "gcweb/v4_0_47": {"cdtsPath":"gcweb/v4_0_47/cdts/","compiled/wet-en.js":"sha512-tnH5+ICb+88XGv1clBrCDzUWXrOAt5nvaiFof1ewyLxhRJ/MaRHbdOaXzAFTOh9TW3/g5VkF9OkikW1civqFTA==","compiled/wet-fr.js":"sha512-5PIFDx8SrhansLOaqmlaRcBKqk3zwbHH5O6fc9KJ2i6qwxaXveeDiz73Fxtmz3/iREvjk9oDeGYM4RNk93aQAA==","cdts-styles.css":"sha512-/T5FIU41V7THC9+5bpPKSj0Aeuf2joUyIpXvTqAi1w4fYFI4w4BXataUGlzgCQF0vcq319tQ+dmuTayab32FkQ==","cdts-app-styles.css":"sha512-oUT4s4bz1vlqoI0kPCRWy6BnuUZLddSL0Lfp13oPDBzzpNjL4r+ejSDoXxkLa41J96kaB7yJk4QXWygRIFFF+w==","cdts-splash-styles.css":"sha512-/8L+im/vk0lx8k7ELdf6MAZr0H6s5mxs66iC3R22UD4qySG1r7eUHdQ5aJ2v+9nNfdIof2TMmH0kC0vlgRvo+g=="},
+    "gcintranet/v4_0_47": {"cdtsPath":"gcintranet/v4_0_47/cdts/","compiled/wet-en.js":"sha512-XyVGRR6hzCvlZoQoLSP1wydsRN9ZYvif8lqU9InPMUzBNu/QoS041cjOtevg2kOp/GLL1lLEaKmHPZEjr4KaTQ==","compiled/wet-fr.js":"sha512-hdzS4GIh0LrY05Evgdn2pLRotzSHYPFh1o57p7HEUr0BIa0z1yovBGA+yekJL58drLfcjX09eRShGOO6Fw5xxw==","cdts-styles.css":"sha512-dqrBeYZXK6RYeYmF7LSMsQ7efhL3Lalpi1P09QpwGXVBbuEB2lnqzhhVN1yPXTYN/5/4UeRlCf3SDtiXnk6sOQ==","cdts-splash-styles.css":"sha512-0ydKRZxST0akj4GM/lin6DobWLxhDLA2k8iPwrTBl4tFS5/0C/ERsRMpurzWf5yalJNqh6ffJcOguX8LB+yAKg==","cdts-eccc-styles.css":"sha512-VjD7joqLvOMRsDY0x+9zCkn/H9RQGHTbiYLGZtLJ+AU3KF9CysP9vI9igQgNxeVgkqagyTCHVBP2y0jDZnEozg==","cdts-esdc-styles.css":"sha512-K10RfHMGrIcS+36XhwMqShTiifXP/cTrMN4y66HPJOeRipyaRtQvrK4VgmodS2QK2IJIyXWSwS8I85uA4MnoTA==","cdts-labour-styles.css":"sha512-K10RfHMGrIcS+36XhwMqShTiifXP/cTrMN4y66HPJOeRipyaRtQvrK4VgmodS2QK2IJIyXWSwS8I85uA4MnoTA=="}
+  }
 }

--- a/gocwebtemplate-core/gocwebtemplate-core-base/src/test/java/goc/webtemplate/component/abstractcorebeantest/CSSPathTest.java
+++ b/gocwebtemplate-core/gocwebtemplate-core-base/src/test/java/goc/webtemplate/component/abstractcorebeantest/CSSPathTest.java
@@ -14,7 +14,7 @@ public class CSSPathTest {
 
         sut.setTheme("gcweb");
 
-        assertTrue(sut.getCssPath().endsWith("/cdts-styles.css"));
+        assertTrue(sut.getCssPathAttributes().contains("/cdts-styles.css"));
     }
 
     @Test
@@ -23,7 +23,7 @@ public class CSSPathTest {
 
         sut.setTheme("gcintranet");
 
-        assertTrue(sut.getCssPath().endsWith("/cdts-styles.css"));
+        assertTrue(sut.getCssPathAttributes().contains("/cdts-styles.css"));
     }
 
     @Test
@@ -33,7 +33,7 @@ public class CSSPathTest {
         sut.setTheme("gcintranet");
         sut.setSubTheme("eSdC"); //test case insensitivity
 
-        assertTrue(sut.getCssPath().endsWith("/cdts-esdc-styles.css"));
+        assertTrue(sut.getCssPathAttributes().contains("/cdts-esdc-styles.css"));
     }
 
     @Test
@@ -43,7 +43,7 @@ public class CSSPathTest {
         sut.setTheme("gcintranet");
         sut.setSubTheme("eCcC"); //test case insensitivity
 
-        assertTrue(sut.getCssPath().endsWith("/cdts-eccc-styles.css"));
+        assertTrue(sut.getCssPathAttributes().contains("/cdts-eccc-styles.css"));
     }
 
     @Test
@@ -52,7 +52,7 @@ public class CSSPathTest {
 
         sut.setTheme("whatever");
 
-        assertTrue(sut.getCssPath().endsWith("/cdts-styles.css"));
+        assertTrue(sut.getCssPathAttributes().contains("/cdts-styles.css"));
     }
 
     @Test
@@ -62,7 +62,7 @@ public class CSSPathTest {
         sut.setTheme("gcintranet");
         sut.setSubTheme("whatever");
 
-        assertTrue(sut.getCssPath().endsWith("/cdts-styles.css"));
+        assertTrue(sut.getCssPathAttributes().contains("/cdts-styles.css"));
     }
 
 	// *************************
@@ -75,7 +75,7 @@ public class CSSPathTest {
 
         sut.setTheme("gcweb");
 
-        assertTrue(sut.getAppCssPath().endsWith("/cdts-app-styles.css"));
+        assertTrue(sut.getAppCssPathAttributes().contains("/cdts-app-styles.css"));
     }
 
     @Test
@@ -84,7 +84,7 @@ public class CSSPathTest {
 
         sut.setTheme("gcintranet");
 
-        assertTrue(sut.getAppCssPath().endsWith("/cdts-styles.css"));
+        assertTrue(sut.getAppCssPathAttributes().contains("/cdts-styles.css"));
     }
 
     @Test
@@ -94,7 +94,7 @@ public class CSSPathTest {
         sut.setTheme("gcintranet");
         sut.setSubTheme("eSdC"); //test case insensitivity
 
-        assertTrue(sut.getAppCssPath().endsWith("/cdts-esdc-styles.css"));
+        assertTrue(sut.getAppCssPathAttributes().contains("/cdts-esdc-styles.css"));
     }
 
     @Test
@@ -104,7 +104,7 @@ public class CSSPathTest {
         sut.setTheme("gcintranet");
         sut.setSubTheme("eCcC"); //test case insensitivity
 
-        assertTrue(sut.getAppCssPath().endsWith("/cdts-eccc-styles.css"));
+        assertTrue(sut.getAppCssPathAttributes().contains("/cdts-eccc-styles.css"));
     }
 
     @Test
@@ -113,7 +113,7 @@ public class CSSPathTest {
 
         sut.setTheme("whatever");
 
-        assertTrue(sut.getAppCssPath().endsWith("/cdts-styles.css"));
+        assertTrue(sut.getAppCssPathAttributes().contains("/cdts-styles.css"));
     }
 
     @Test
@@ -123,7 +123,7 @@ public class CSSPathTest {
         sut.setTheme("gcintranet");
         sut.setSubTheme("whatever");
 
-        assertTrue(sut.getAppCssPath().endsWith("/cdts-styles.css"));
+        assertTrue(sut.getAppCssPathAttributes().contains("/cdts-styles.css"));
     }
 
 	// *************************
@@ -136,7 +136,7 @@ public class CSSPathTest {
 
         sut.setTheme("gcweb");
 
-        assertTrue(sut.getSplashCssPath().endsWith("/cdts-splash-styles.css"));
+        assertTrue(sut.getSplashCssPathAttributes().contains("/cdts-splash-styles.css"));
     }
 
     @Test
@@ -145,6 +145,6 @@ public class CSSPathTest {
 
         sut.setTheme("gcintranet");
 
-        assertTrue(sut.getSplashCssPath().endsWith("/cdts-splash-styles.css"));
+        assertTrue(sut.getSplashCssPathAttributes().contains("/cdts-splash-styles.css"));
     }
 }

--- a/gocwebtemplate-core/gocwebtemplate-core-base/src/test/java/goc/webtemplate/component/abstractcorebeantest/SRITest.java
+++ b/gocwebtemplate-core/gocwebtemplate-core-base/src/test/java/goc/webtemplate/component/abstractcorebeantest/SRITest.java
@@ -1,0 +1,58 @@
+package goc.webtemplate.component.abstractcorebeantest;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import goc.webtemplate.Constants;
+
+public class SRITest {
+
+    @Test
+    public void testNoSRIForUnknownVersion() {
+        AbstractCoreBeanImpl sut = new AbstractCoreBeanImpl();
+
+        sut.setUseSRI(true);
+        sut.setTheme("gcweb");
+        sut.setTemplateVersion("v999_999_999");
+
+        assertTrue(sut.getCssPathAttributes().contains("v999_999_999"));
+        assertTrue(!sut.getCssPathAttributes().contains("integrity"));
+        assertTrue(!sut.getWetJsPathAttributes().contains("integrity"));
+    }
+
+    @Test
+    public void testHasSRIForGCWebDefaultVersion() {
+        AbstractCoreBeanImpl sut = new AbstractCoreBeanImpl();
+
+        sut.setUseSRI(true);
+        sut.setTheme("gcweb");
+
+        assertTrue(sut.getCssPathAttributes().contains(Constants.CDTS_DEFAULT_VERSION));
+        assertTrue(sut.getCssPathAttributes().contains("integrity"));
+        assertTrue(sut.getWetJsPathAttributes().contains("integrity"));
+    }
+
+    @Test
+    public void testHasSRIForGCIntranetDefaultVersion() {
+        AbstractCoreBeanImpl sut = new AbstractCoreBeanImpl();
+
+        sut.setUseSRI(true);
+        sut.setTheme("gcintranet");
+
+        assertTrue(sut.getCssPathAttributes().contains(Constants.CDTS_DEFAULT_VERSION));
+        assertTrue(sut.getCssPathAttributes().contains("integrity"));
+        assertTrue(sut.getWetJsPathAttributes().contains("integrity"));
+    }
+
+    @Test
+    public void testNoSRIWhenDisabled() {
+        AbstractCoreBeanImpl sut = new AbstractCoreBeanImpl();
+
+        sut.setUseSRI(false);
+        sut.setTheme("gcweb");
+
+        assertTrue(!sut.getCssPathAttributes().contains("integrity"));
+        assertTrue(!sut.getWetJsPathAttributes().contains("integrity"));
+    }
+}

--- a/gocwebtemplate-core/gocwebtemplate-core-base/src/test/resources/goc/webtemplate/global/config/cdn.properties
+++ b/gocwebtemplate-core/gocwebtemplate-core-base/src/test/resources/goc/webtemplate/global/config/cdn.properties
@@ -5,12 +5,6 @@
 #       PROD_SSL_ECCCSUB, (gcintranet Theme, eccc SubTheme, always https)
 #       PROD_UNSECURE,  (gcintranet Theme, never https) 
 #       ESDC_PROD,  (For Internal ESDC USE ONLY, gcintranet Theme, esdc Subtheme)
-#       ESDC_GCINTRANET_SADE,  (For Internal ESDC USE ONLY, gcintranet Theme)
-#       ESDC_GCINTRANET_QA,  (For Internal ESDC USE ONLY, gcintranet Theme)
-#       ESDC_GCINTRANET_ESDCSUB_SADE,  (For Internal ESDC USE ONLY, gcintranet Theme, esdc Subtheme)
-#       ESDC_GCINTRANET_ESDCSUB_QA,  (For Internal ESDC USE ONLY, gcintranet Theme, esdc Subtheme)
-#       ESDC_GCWEB_SADE, (For Internal ESDC USE ONLY, gcweb Theme)
-#       ESDC_GCWEB_QA, (For Internal ESDC USE ONLY, gcweb Theme)
 #       localdev  (requires more setup, see cdn_localdev_* properties below)
 cdn_environment=Akamai
 # When selecting "localdev" environment (when the CDTS files are hosted locally within the app, 
@@ -32,6 +26,7 @@ wettemplate_subtheme=
 wettemplate_version=v4_0_47
 wettemplate_loadjqueryfromgoogle=false
 webtemplate_usehttps=true
+webtemplate_usesri=true
 #
 # Session related properties
 session.timeout.enabled=false

--- a/gocwebtemplate-core/gocwebtemplate-core-jsp/src/test/resources/goc/webtemplate/global/config/cdn.properties
+++ b/gocwebtemplate-core/gocwebtemplate-core-jsp/src/test/resources/goc/webtemplate/global/config/cdn.properties
@@ -5,12 +5,6 @@
 #       PROD_SSL_ECCCSUB, (gcintranet Theme, eccc SubTheme, always https)
 #       PROD_UNSECURE,  (gcintranet Theme, never https) 
 #       ESDC_PROD,  (For Internal ESDC USE ONLY, gcintranet Theme, esdc Subtheme)
-#       ESDC_GCINTRANET_SADE,  (For Internal ESDC USE ONLY, gcintranet Theme)
-#       ESDC_GCINTRANET_QA,  (For Internal ESDC USE ONLY, gcintranet Theme)
-#       ESDC_GCINTRANET_ESDCSUB_SADE,  (For Internal ESDC USE ONLY, gcintranet Theme, esdc Subtheme)
-#       ESDC_GCINTRANET_ESDCSUB_QA,  (For Internal ESDC USE ONLY, gcintranet Theme, esdc Subtheme)
-#       ESDC_GCWEB_SADE, (For Internal ESDC USE ONLY, gcweb Theme)
-#       ESDC_GCWEB_QA, (For Internal ESDC USE ONLY, gcweb Theme)
 #       localdev  (requires more setup, see cdn_localdev_* properties below)
 cdn_environment=PROD_SSL
 # When selecting "localdev" environment (when the CDTS files are hosted locally within the app, 
@@ -32,6 +26,7 @@ wettemplate_subtheme=
 wettemplate_version=v4_0_47
 wettemplate_loadjqueryfromgoogle=false
 webtemplate_usehttps=true
+webtemplate_usesri=true
 #
 # Session related properties
 session.timeout.enabled=false

--- a/gocwebtemplate-core/gocwebtemplate-core-spring/src/main/resources/goc/webtemplate/goc_layouts/application-leftmenu-master-template.html
+++ b/gocwebtemplate-core/gocwebtemplate-core-spring/src/main/resources/goc/webtemplate/goc_layouts/application-leftmenu-master-template.html
@@ -9,8 +9,8 @@
 	    <div layout:fragment="title" th:remove="tag"><title th:text="${goctemplateclientbean.headerTitle}"></title></div>
 	    <meta content="width=device-width,initial-scale=1" name="viewport" />
 	    <!-- Load closure template scripts -->
-        <link rel="stylesheet" th:href="${goctemplateclientbean.appCssPath}">
-        <script th:remove="tag" th:utext='|<script type="text/javascript" src="${goctemplateclientbean.wetJsPath}" data-cdts-setup=&apos;${goctemplateclientbean.renderAppSetup}&apos;></script>|'></script>
+        <link th:remove="tag" th:utext='|<link rel="stylesheet" ${goctemplateclientbean.appCssPathAttributes}>|'>
+        <script th:remove="tag" th:utext='|<script type="text/javascript" ${goctemplateclientbean.wetJsPathAttributes} data-cdts-setup=&apos;${goctemplateclientbean.renderAppSetup}&apos;></script>|'></script>
 	    <noscript>
 	    	<!-- Write closure fall-back static file -->
 	    	[(${@applicationscopebean.getStaticFile(goctemplateclientbean.staticFallbackFilePath, goctemplateclientbean.theme, 'refTop.html')})]

--- a/gocwebtemplate-core/gocwebtemplate-core-spring/src/main/resources/goc/webtemplate/goc_layouts/application-master-template.html
+++ b/gocwebtemplate-core/gocwebtemplate-core-spring/src/main/resources/goc/webtemplate/goc_layouts/application-master-template.html
@@ -9,8 +9,8 @@
 	    <div layout:fragment="title" th:remove="tag"><title th:text="${goctemplateclientbean.headerTitle}"></title></div>
 	    <meta content="width=device-width,initial-scale=1" name="viewport" />
 	    <!-- Load closure template scripts -->
-        <link rel="stylesheet" th:href="${goctemplateclientbean.appCssPath}">
-        <script th:remove="tag" th:utext='|<script type="text/javascript" src="${goctemplateclientbean.wetJsPath}" data-cdts-setup=&apos;${goctemplateclientbean.renderAppSetup}&apos;></script>|'></script>
+        <link th:remove="tag" th:utext='|<link rel="stylesheet" ${goctemplateclientbean.appCssPathAttributes}>|'>
+        <script th:remove="tag" th:utext='|<script type="text/javascript" ${goctemplateclientbean.wetJsPathAttributes} data-cdts-setup=&apos;${goctemplateclientbean.renderAppSetup}&apos;></script>|'></script>
 	    <noscript>
 	    	<!-- Write closure fall-back static file -->
 	    	[(${@applicationscopebean.getStaticFile(goctemplateclientbean.staticFallbackFilePath, goctemplateclientbean.theme, 'refTop.html')})]

--- a/gocwebtemplate-core/gocwebtemplate-core-spring/src/main/resources/goc/webtemplate/goc_layouts/bilingualerror-master-template.html
+++ b/gocwebtemplate-core/gocwebtemplate-core-spring/src/main/resources/goc/webtemplate/goc_layouts/bilingualerror-master-template.html
@@ -9,8 +9,8 @@
 	    <div layout:fragment="title" th:remove="tag"><title th:text="${goctemplateclientbean.headerTitle}"></title></div>
 	    <meta content="width=device-width,initial-scale=1" name="viewport" />
 	    <!-- Load closure template scripts -->
-        <link rel="stylesheet" th:href="${goctemplateclientbean.cssPath}">
-        <script th:remove="tag" th:utext='|<script type="text/javascript" src="${goctemplateclientbean.wetJsPath}" data-cdts-setup=&apos;${goctemplateclientbean.renderServerSetup}&apos;></script>|'></script>
+        <link th:remove="tag" th:utext='|<link rel="stylesheet" ${goctemplateclientbean.cssPathAttributes}>|'>
+        <script th:remove="tag" th:utext='|<script type="text/javascript" ${goctemplateclientbean.wetJsPathAttributes} data-cdts-setup=&apos;${goctemplateclientbean.renderServerSetup}&apos;></script>|'></script>
 	    <noscript>
 	    	<!-- Write closure fall-back static file -->
 	    	[(${@applicationscopebean.getStaticFile(goctemplateclientbean.staticFallbackFilePath, goctemplateclientbean.theme, 'serverRefTop.html')})]

--- a/gocwebtemplate-core/gocwebtemplate-core-spring/src/main/resources/goc/webtemplate/goc_layouts/leftmenu-master-template.html
+++ b/gocwebtemplate-core/gocwebtemplate-core-spring/src/main/resources/goc/webtemplate/goc_layouts/leftmenu-master-template.html
@@ -9,8 +9,8 @@
 	    <div layout:fragment="title" th:remove="tag"><title th:text="${goctemplateclientbean.headerTitle}"></title></div>
 	    <meta content="width=device-width,initial-scale=1" name="viewport" />
 	    <!-- Load closure template scripts -->
-        <link rel="stylesheet" th:href="${goctemplateclientbean.cssPath}">
-        <script th:remove="tag" th:utext='|<script type="text/javascript" src="${goctemplateclientbean.wetJsPath}" data-cdts-setup=&apos;${goctemplateclientbean.renderSetup}&apos;></script>|'></script>
+        <link th:remove="tag" th:utext='|<link rel="stylesheet" ${goctemplateclientbean.cssPathAttributes}>|'>
+        <script th:remove="tag" th:utext='|<script type="text/javascript" ${goctemplateclientbean.wetJsPathAttributes} data-cdts-setup=&apos;${goctemplateclientbean.renderSetup}&apos;></script>|'></script>
 	    <noscript>
 	    	<!-- Write closure fall-back static file -->
 	    	[(${@applicationscopebean.getStaticFile(goctemplateclientbean.staticFallbackFilePath, goctemplateclientbean.theme, 'refTop.html')})]

--- a/gocwebtemplate-core/gocwebtemplate-core-spring/src/main/resources/goc/webtemplate/goc_layouts/master-template.html
+++ b/gocwebtemplate-core/gocwebtemplate-core-spring/src/main/resources/goc/webtemplate/goc_layouts/master-template.html
@@ -9,8 +9,8 @@
 	    <div layout:fragment="title" th:remove="tag"><title th:text="${goctemplateclientbean.headerTitle}"></title></div>
 	    <meta content="width=device-width,initial-scale=1" name="viewport" />
 	    <!-- Load closure template scripts -->
-	    <link rel="stylesheet" th:href="${goctemplateclientbean.cssPath}">
-        <script th:remove="tag" th:utext='|<script type="text/javascript" src="${goctemplateclientbean.wetJsPath}" data-cdts-setup=&apos;${goctemplateclientbean.renderSetup}&apos;></script>|'></script>
+	    <link th:remove="tag" th:utext='|<link rel="stylesheet" ${goctemplateclientbean.cssPathAttributes}>|'>
+        <script th:remove="tag" th:utext='|<script type="text/javascript" ${goctemplateclientbean.wetJsPathAttributes} data-cdts-setup=&apos;${goctemplateclientbean.renderSetup}&apos;></script>|'></script>
 	    <noscript>
 	    	<!-- Write closure fall-back static file -->
 	    	[(${@applicationscopebean.getStaticFile(goctemplateclientbean.staticFallbackFilePath, goctemplateclientbean.theme, 'refTop.html')})]

--- a/gocwebtemplate-core/gocwebtemplate-core-spring/src/main/resources/goc/webtemplate/goc_layouts/splash-template.html
+++ b/gocwebtemplate-core/gocwebtemplate-core-spring/src/main/resources/goc/webtemplate/goc_layouts/splash-template.html
@@ -7,8 +7,8 @@
     	<div layout:fragment="title" th:remove="tag"><title th:text="${goctemplateclientbean.headerTitle}"></title></div>
 	    <meta content="width=device-width,initial-scale=1" name="viewport" />
 	    <!-- Load closure template scripts -->
-        <link rel="stylesheet" th:href="${goctemplateclientbean.splashCssPath}">
-        <script th:remove="tag" th:utext='|<script type="text/javascript" src="${goctemplateclientbean.wetJsPath}" data-cdts-setup=&apos;${goctemplateclientbean.renderSplashSetup}&apos;></script>|'></script>
+        <link th:remove="tag" th:utext='|<link rel="stylesheet" ${goctemplateclientbean.splashCssPathAttributes}>|'>
+        <script th:remove="tag" th:utext='|<script type="text/javascript" ${goctemplateclientbean.wetJsPathAttributes} data-cdts-setup=&apos;${goctemplateclientbean.renderSplashSetup}&apos;></script>|'></script>
 	    <noscript>
 	    	<!-- Write closure fall-back static file -->
 	    	[(${@applicationscopebean.getStaticFile(goctemplateclientbean.staticFallbackFilePath, goctemplateclientbean.theme, 'splashTop.html')})]

--- a/gocwebtemplate-core/gocwebtemplate-core-spring/src/main/resources/goc/webtemplate/goc_layouts/transactional-leftmenu-master-template.html
+++ b/gocwebtemplate-core/gocwebtemplate-core-spring/src/main/resources/goc/webtemplate/goc_layouts/transactional-leftmenu-master-template.html
@@ -9,8 +9,8 @@
 	    <div layout:fragment="title" th:remove="tag"><title th:text="${goctemplateclientbean.headerTitle}"></title></div>
 	    <meta content="width=device-width,initial-scale=1" name="viewport" />
 	    <!-- Load closure template scripts -->
-        <link rel="stylesheet" th:href="${goctemplateclientbean.cssPath}">
-        <script th:remove="tag" th:utext='|<script type="text/javascript" src="${goctemplateclientbean.wetJsPath}" data-cdts-setup=&apos;${goctemplateclientbean.renderTransactionalSetup}&apos;></script>|'></script>
+        <link th:remove="tag" th:utext='|<link rel="stylesheet" ${goctemplateclientbean.cssPathAttributes}>|'>
+        <script th:remove="tag" th:utext='|<script type="text/javascript" ${goctemplateclientbean.wetJsPathAttributes} data-cdts-setup=&apos;${goctemplateclientbean.renderTransactionalSetup}&apos;></script>|'></script>
 	    <noscript>
 	    	<!-- Write closure fall-back static file -->
 	    	[(${@applicationscopebean.getStaticFile(goctemplateclientbean.staticFallbackFilePath, goctemplateclientbean.theme, 'refTop.html')})]

--- a/gocwebtemplate-core/gocwebtemplate-core-spring/src/main/resources/goc/webtemplate/goc_layouts/transactional-master-template.html
+++ b/gocwebtemplate-core/gocwebtemplate-core-spring/src/main/resources/goc/webtemplate/goc_layouts/transactional-master-template.html
@@ -9,8 +9,8 @@
 	    <div layout:fragment="title" th:remove="tag"><title th:text="${goctemplateclientbean.headerTitle}"></title></div>
 	    <meta content="width=device-width,initial-scale=1" name="viewport" />
 	    <!-- Load closure template scripts -->
-        <link rel="stylesheet" th:href="${goctemplateclientbean.cssPath}">
-        <script th:remove="tag" th:utext='|<script type="text/javascript" src="${goctemplateclientbean.wetJsPath}" data-cdts-setup=&apos;${goctemplateclientbean.renderTransactionalSetup}&apos;></script>|'></script>
+        <link th:remove="tag" th:utext='|<link rel="stylesheet" ${goctemplateclientbean.cssPathAttributes}>|'>
+        <script th:remove="tag" th:utext='|<script type="text/javascript" ${goctemplateclientbean.wetJsPathAttributes} data-cdts-setup=&apos;${goctemplateclientbean.renderTransactionalSetup}&apos;></script>|'></script>
 	    <noscript>
 	    	<!-- Write closure fall-back static file -->
 	    	[(${@applicationscopebean.getStaticFile(goctemplateclientbean.staticFallbackFilePath, goctemplateclientbean.theme, 'refTop.html')})]

--- a/gocwebtemplate-core/gocwebtemplate-core-spring/src/main/resources/goc/webtemplate/goc_layouts/unilingualerror-master-template.html
+++ b/gocwebtemplate-core/gocwebtemplate-core-spring/src/main/resources/goc/webtemplate/goc_layouts/unilingualerror-master-template.html
@@ -9,8 +9,8 @@
 	    <div layout:fragment="title" th:remove="tag"><title th:text="${goctemplateclientbean.headerTitle}"></title></div>
 	    <meta content="width=device-width,initial-scale=1" name="viewport" />
 	    <!-- Load closure template scripts -->
-        <link rel="stylesheet" th:href="${goctemplateclientbean.cssPath}">
-        <script th:remove="tag" th:utext='|<script type="text/javascript" src="${goctemplateclientbean.wetJsPath}" data-cdts-setup=&apos;${goctemplateclientbean.renderUnilingualErrorSetup}&apos;></script>|'></script>
+        <link th:remove="tag" th:utext='|<link rel="stylesheet" ${goctemplateclientbean.cssPathAttributes}>|'>
+        <script th:remove="tag" th:utext='|<script type="text/javascript" ${goctemplateclientbean.wetJsPathAttributes} data-cdts-setup=&apos;${goctemplateclientbean.renderUnilingualErrorSetup}&apos;></script>|'></script>
 	    <noscript>
 	    	<!-- Write closure fall-back static file -->
 	    	[(${@applicationscopebean.getStaticFile(goctemplateclientbean.staticFallbackFilePath, goctemplateclientbean.theme, 'refTop.html')})]

--- a/gocwebtemplate-sample-jsp/src/main/resources/goc/webtemplate/global/config/cdn.properties
+++ b/gocwebtemplate-sample-jsp/src/main/resources/goc/webtemplate/global/config/cdn.properties
@@ -5,12 +5,6 @@
 #       PROD_SSL_ECCCSUB, (gcintranet Theme, eccc SubTheme, always https)
 #       PROD_UNSECURE,  (gcintranet Theme, never https) 
 #       ESDC_PROD,  (For Internal ESDC USE ONLY, gcintranet Theme, esdc Subtheme)
-#       ESDC_GCINTRANET_SADE,  (For Internal ESDC USE ONLY, gcintranet Theme)
-#       ESDC_GCINTRANET_QA,  (For Internal ESDC USE ONLY, gcintranet Theme)
-#       ESDC_GCINTRANET_ESDCSUB_SADE,  (For Internal ESDC USE ONLY, gcintranet Theme, esdc Subtheme)
-#       ESDC_GCINTRANET_ESDCSUB_QA,  (For Internal ESDC USE ONLY, gcintranet Theme, esdc Subtheme)
-#       ESDC_GCWEB_SADE, (For Internal ESDC USE ONLY, gcweb Theme)
-#       ESDC_GCWEB_QA, (For Internal ESDC USE ONLY, gcweb Theme)
 #       localdev  (requires more setup, see cdn_localdev_* properties below)
 cdn_environment=Akamai
 # When selecting "localdev" environment (when the CDTS files are hosted locally within the app, 
@@ -32,6 +26,7 @@ wettemplate_subtheme=
 wettemplate_version=
 wettemplate_loadjqueryfromgoogle=false
 webtemplate_usehttps=true
+webtemplate_usesri=true
 #
 # Session related properties
 session.timeout.enabled=false

--- a/gocwebtemplate-sample-jsp/src/main/webapp/templates/application-leftmenu-mastertemplate.jsp
+++ b/gocwebtemplate-sample-jsp/src/main/webapp/templates/application-leftmenu-mastertemplate.jsp
@@ -28,8 +28,8 @@
         <title><tiles:insertAttribute name="title" /><s:property value="#goctemplateclientbean.headerTitle"/></title>
         <meta content="width=device-width,initial-scale=1" name="viewport" />
         <!-- Load closure template scripts -->
-        <link rel="stylesheet" href="<s:property value="#goctemplateclientbean.appCssPath"/>">
-        <script type="text/javascript" src="<s:property value="#goctemplateclientbean.wetJsPath"/>" data-cdts-setup='<s:property escapeHtml="false" value="#goctemplateclientbean.renderAppSetup"/>'></script>
+        <link rel="stylesheet" <s:property escapeHtml="false" value="#goctemplateclientbean.appCssPathAttributes"/>>
+        <script type="text/javascript" <s:property escapeHtml="false" value="#goctemplateclientbean.wetJsPathAttributes"/> data-cdts-setup='<s:property escapeHtml="false" value="#goctemplateclientbean.renderAppSetup"/>'></script>
         <noscript>
             <!-- Write closure fall-back static file -->
             <s:property escapeHtml="false" value="%{#applicationscopebean.getStaticFile(#goctemplateclientbean.staticFallbackFilePath, #request.wettheme, 'refTop.html')}" />

--- a/gocwebtemplate-sample-jsp/src/main/webapp/templates/application-mastertemplate.jsp
+++ b/gocwebtemplate-sample-jsp/src/main/webapp/templates/application-mastertemplate.jsp
@@ -28,8 +28,8 @@
         <title><tiles:insertAttribute name="title" /><s:property value="#goctemplateclientbean.headerTitle"/></title>
         <meta content="width=device-width,initial-scale=1" name="viewport" />
         <!-- Load closure template scripts -->
-        <link rel="stylesheet" href="<s:property value="#goctemplateclientbean.appCssPath"/>">
-        <script type="text/javascript" src="<s:property value="#goctemplateclientbean.wetJsPath"/>" data-cdts-setup='<s:property escapeHtml="false" value="#goctemplateclientbean.renderAppSetup"/>'></script>
+        <link rel="stylesheet" <s:property escapeHtml="false" value="#goctemplateclientbean.appCssPathAttributes"/>>
+        <script type="text/javascript" <s:property escapeHtml="false" value="#goctemplateclientbean.wetJsPathAttributes"/> data-cdts-setup='<s:property escapeHtml="false" value="#goctemplateclientbean.renderAppSetup"/>'></script>
         <noscript>
             <!-- Write closure fall-back static file -->
             <s:property escapeHtml="false" value="%{#applicationscopebean.getStaticFile(#goctemplateclientbean.staticFallbackFilePath, #request.wettheme, 'refTop.html')}" />

--- a/gocwebtemplate-sample-jsp/src/main/webapp/templates/bilingualerror-mastertemplate.jsp
+++ b/gocwebtemplate-sample-jsp/src/main/webapp/templates/bilingualerror-mastertemplate.jsp
@@ -28,8 +28,8 @@
         <title><tiles:insertAttribute name="title" /><s:property value="#goctemplateclientbean.headerTitle"/></title>
         <meta content="width=device-width,initial-scale=1" name="viewport" />
         <!-- Load closure template scripts -->
-        <link rel="stylesheet" href="<s:property value="#goctemplateclientbean.cssPath"/>">
-        <script type="text/javascript" src="<s:property value="#goctemplateclientbean.wetJsPath"/>" data-cdts-setup='<s:property escapeHtml="false" value="#goctemplateclientbean.renderServerSetup"/>'></script>
+        <link rel="stylesheet" <s:property escapeHtml="false" value="#goctemplateclientbean.cssPathAttributes"/>>
+        <script type="text/javascript" <s:property escapeHtml="false" value="#goctemplateclientbean.wetJsPathAttributes"/> data-cdts-setup='<s:property escapeHtml="false" value="#goctemplateclientbean.renderServerSetup"/>'></script>
         <noscript>
             <!-- Write closure fall-back static file -->
             <s:property escapeHtml="false" value="%{#applicationscopebean.getStaticFile(#goctemplateclientbean.staticFallbackFilePath, #request.wettheme, 'serverRefTop.html')}" />

--- a/gocwebtemplate-sample-jsp/src/main/webapp/templates/leftmenu-mastertemplate.jsp
+++ b/gocwebtemplate-sample-jsp/src/main/webapp/templates/leftmenu-mastertemplate.jsp
@@ -28,8 +28,8 @@
         <title><tiles:insertAttribute name="title" /><s:property value="#goctemplateclientbean.headerTitle"/></title>
         <meta content="width=device-width,initial-scale=1" name="viewport" />
         <!-- Load closure template scripts -->
-        <link rel="stylesheet" href="<s:property value="#goctemplateclientbean.cssPath"/>">
-        <script type="text/javascript" src="<s:property value="#goctemplateclientbean.wetJsPath"/>" data-cdts-setup='<s:property escapeHtml="false" value="#goctemplateclientbean.renderSetup"/>'></script>
+        <link rel="stylesheet" <s:property escapeHtml="false" value="#goctemplateclientbean.cssPathAttributes"/>>
+        <script type="text/javascript" <s:property escapeHtml="false" value="#goctemplateclientbean.wetJsPathAttributes"/> data-cdts-setup='<s:property escapeHtml="false" value="#goctemplateclientbean.renderSetup"/>'></script>
         <noscript>
             <!-- Write closure fall-back static file -->
             <s:property escapeHtml="false" value="%{#applicationscopebean.getStaticFile(#goctemplateclientbean.staticFallbackFilePath, #request.wettheme, 'refTop.html')}" />

--- a/gocwebtemplate-sample-jsp/src/main/webapp/templates/mastertemplate.jsp
+++ b/gocwebtemplate-sample-jsp/src/main/webapp/templates/mastertemplate.jsp
@@ -28,8 +28,8 @@
         <title><tiles:insertAttribute name="title" /><s:property value="#goctemplateclientbean.headerTitle"/></title>
         <meta content="width=device-width,initial-scale=1" name="viewport" />
         <!-- Load closure template scripts -->
-        <link rel="stylesheet" href="<s:property value="#goctemplateclientbean.cssPath"/>">
-        <script type="text/javascript" src="<s:property value="#goctemplateclientbean.wetJsPath"/>" data-cdts-setup='<s:property escapeHtml="false" value="#goctemplateclientbean.renderSetup"/>'></script>
+        <link rel="stylesheet" <s:property escapeHtml="false" value="#goctemplateclientbean.cssPathAttributes"/>>
+        <script type="text/javascript" <s:property escapeHtml="false" value="#goctemplateclientbean.wetJsPathAttributes"/> data-cdts-setup='<s:property escapeHtml="false" value="#goctemplateclientbean.renderSetup"/>'></script>
         <noscript>
             <!-- Write closure fall-back static file -->
             <s:property escapeHtml="false" value="%{#applicationscopebean.getStaticFile(#goctemplateclientbean.staticFallbackFilePath, #request.wettheme, 'refTop.html')}" />

--- a/gocwebtemplate-sample-jsp/src/main/webapp/templates/splashtemplate.jsp
+++ b/gocwebtemplate-sample-jsp/src/main/webapp/templates/splashtemplate.jsp
@@ -28,8 +28,8 @@
         <title><tiles:insertAttribute name="title" /><s:property value="#goctemplateclientbean.headerTitle"/></title>
         <meta content="width=device-width,initial-scale=1" name="viewport" />
         <!-- Load closure template scripts -->
-        <link rel="stylesheet" href="<s:property value="#goctemplateclientbean.splashCssPath"/>">
-        <script type="text/javascript" src="<s:property value="#goctemplateclientbean.wetJsPath"/>" data-cdts-setup='<s:property escapeHtml="false" value="#goctemplateclientbean.renderSplashSetup"/>'></script>
+        <link rel="stylesheet" <s:property escapeHtml="false" value="#goctemplateclientbean.splashCssPathAttributes"/>>
+        <script type="text/javascript" <s:property escapeHtml="false" value="#goctemplateclientbean.wetJsPathAttributes"/> data-cdts-setup='<s:property escapeHtml="false" value="#goctemplateclientbean.renderSplashSetup"/>'></script>
         <noscript>
             <!-- Write closure fall-back static file -->
             <s:property escapeHtml="false" value="%{#applicationscopebean.getStaticFile(#goctemplateclientbean.staticFallbackFilePath, #request.wettheme, 'splashTop.html')}" />

--- a/gocwebtemplate-sample-jsp/src/main/webapp/templates/transactional-leftmenu-mastertemplate.jsp
+++ b/gocwebtemplate-sample-jsp/src/main/webapp/templates/transactional-leftmenu-mastertemplate.jsp
@@ -28,8 +28,8 @@
         <title><tiles:insertAttribute name="title" /><s:property value="#goctemplateclientbean.headerTitle"/></title>
         <meta content="width=device-width,initial-scale=1" name="viewport" />
         <!-- Load closure template scripts -->
-        <link rel="stylesheet" href="<s:property value="#goctemplateclientbean.cssPath"/>">
-        <script type="text/javascript" src="<s:property value="#goctemplateclientbean.wetJsPath"/>" data-cdts-setup='<s:property escapeHtml="false" value="#goctemplateclientbean.renderTransactionalSetup"/>'></script>
+        <link rel="stylesheet" <s:property escapeHtml="false" value="#goctemplateclientbean.cssPathAttributes"/>>
+        <script type="text/javascript" <s:property escapeHtml="false" value="#goctemplateclientbean.wetJsPathAttributes"/> data-cdts-setup='<s:property escapeHtml="false" value="#goctemplateclientbean.renderTransactionalSetup"/>'></script>
         <noscript>
             <!-- Write closure fall-back static file -->
             <s:property escapeHtml="false" value="%{#applicationscopebean.getStaticFile(#goctemplateclientbean.staticFallbackFilePath, #request.wettheme, 'refTop.html')}" />

--- a/gocwebtemplate-sample-jsp/src/main/webapp/templates/transactional-mastertemplate.jsp
+++ b/gocwebtemplate-sample-jsp/src/main/webapp/templates/transactional-mastertemplate.jsp
@@ -28,8 +28,8 @@
         <title><tiles:insertAttribute name="title" /><s:property value="#goctemplateclientbean.headerTitle"/></title>
         <meta content="width=device-width,initial-scale=1" name="viewport" />
         <!-- Load closure template scripts -->
-        <link rel="stylesheet" href="<s:property value="#goctemplateclientbean.cssPath"/>">
-        <script type="text/javascript" src="<s:property value="#goctemplateclientbean.wetJsPath"/>" data-cdts-setup='<s:property escapeHtml="false" value="#goctemplateclientbean.renderTransactionalSetup"/>'></script>
+        <link rel="stylesheet" <s:property escapeHtml="false" value="#goctemplateclientbean.cssPathAttributes"/>>
+        <script type="text/javascript" <s:property escapeHtml="false" value="#goctemplateclientbean.wetJsPathAttributes"/> data-cdts-setup='<s:property escapeHtml="false" value="#goctemplateclientbean.renderTransactionalSetup"/>'></script>
         <noscript>
             <!-- Write closure fall-back static file -->
             <s:property escapeHtml="false" value="%{#applicationscopebean.getStaticFile(#goctemplateclientbean.staticFallbackFilePath, #request.wettheme, 'refTop.html')}" />

--- a/gocwebtemplate-sample-jsp/src/main/webapp/templates/unilingualerror-mastertemplate.jsp
+++ b/gocwebtemplate-sample-jsp/src/main/webapp/templates/unilingualerror-mastertemplate.jsp
@@ -28,8 +28,8 @@
         <title><tiles:insertAttribute name="title" /><s:property value="#goctemplateclientbean.headerTitle"/></title>
         <meta content="width=device-width,initial-scale=1" name="viewport" />
         <!-- Load closure template scripts -->
-        <link rel="stylesheet" href="<s:property value="#goctemplateclientbean.cssPath"/>">
-        <script type="text/javascript" src="<s:property value="#goctemplateclientbean.wetJsPath"/>" data-cdts-setup='<s:property escapeHtml="false" value="#goctemplateclientbean.renderUnilingualErrorSetup"/>'></script>
+        <link rel="stylesheet" <s:property escapeHtml="false" value="#goctemplateclientbean.cssPathAttributes"/>>
+        <script type="text/javascript" <s:property escapeHtml="false" value="#goctemplateclientbean.wetJsPathAttributes"/> data-cdts-setup='<s:property escapeHtml="false" value="#goctemplateclientbean.renderUnilingualErrorSetup"/>'></script>
         <noscript>
             <!-- Write closure fall-back static file -->
             <s:property escapeHtml="false" value="%{#applicationscopebean.getStaticFile(#goctemplateclientbean.staticFallbackFilePath, #request.wettheme, 'refTop.html')}" />

--- a/gocwebtemplate-sample-spring/src/main/resources/goc/webtemplate/global/config/cdn.properties
+++ b/gocwebtemplate-sample-spring/src/main/resources/goc/webtemplate/global/config/cdn.properties
@@ -5,12 +5,6 @@
 #       PROD_SSL_ECCCSUB, (gcintranet Theme, eccc SubTheme, always https)
 #       PROD_UNSECURE,  (gcintranet Theme, never https) 
 #       ESDC_PROD,  (For Internal ESDC USE ONLY, gcintranet Theme, esdc Subtheme)
-#       ESDC_GCINTRANET_SADE,  (For Internal ESDC USE ONLY, gcintranet Theme)
-#       ESDC_GCINTRANET_QA,  (For Internal ESDC USE ONLY, gcintranet Theme)
-#       ESDC_GCINTRANET_ESDCSUB_SADE,  (For Internal ESDC USE ONLY, gcintranet Theme, esdc Subtheme)
-#       ESDC_GCINTRANET_ESDCSUB_QA,  (For Internal ESDC USE ONLY, gcintranet Theme, esdc Subtheme)
-#       ESDC_GCWEB_SADE, (For Internal ESDC USE ONLY, gcweb Theme)
-#       ESDC_GCWEB_QA, (For Internal ESDC USE ONLY, gcweb Theme)
 #       localdev  (requires more setup, see cdn_localdev_* properties below)
 cdn_environment=Akamai
 # When selecting "localdev" environment (when the CDTS files are hosted locally within the app, 
@@ -32,6 +26,7 @@ wettemplate_subtheme=
 wettemplate_version=
 wettemplate_loadjqueryfromgoogle=false
 webtemplate_usehttps=true
+webtemplate_usesri=true
 #
 # Session related properties
 session.timeout.enabled=false


### PR DESCRIPTION
- Adding support for SRI for "JavaTemplate -> CDTS" as well as "CDTS -> internal/WET"
  - This meant refactoring the cssPath/wetJsPath functions
- Fixing "rn" version support that was broken when default version was introduced.  
  - NOTE: "rn" version will not work with CDTS v4_0_47 now that we're using setup function. Will start working again with CDTS v4_1_0+.
- Cleanup of CDTSEnvironments.json