### PR TITLE
Bump of maven-war-plugin to latest version for compatibility with java17+

### DIFF
--- a/gocwebtemplate-core/gocwebtemplate-core-spring/src/test/java/goc/webtemplate/component/spring/DefaultTemplateCoreBeanTest.java
+++ b/gocwebtemplate-core/gocwebtemplate-core-spring/src/test/java/goc/webtemplate/component/spring/DefaultTemplateCoreBeanTest.java
@@ -3,7 +3,7 @@ package goc.webtemplate.component.spring;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(classes = WebConfigSpring.class)
 class DefaultTemplateCoreBeanTest {
 	
 	//TODO: Complete this test case

--- a/gocwebtemplate-sample-jsp/pom.xml
+++ b/gocwebtemplate-sample-jsp/pom.xml
@@ -36,7 +36,7 @@
       <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-war-plugin</artifactId>
-          <version>2.6</version>
+          <version>3.4.0</version>
           <configuration>
             <failOnMissingWebXml>true</failOnMissingWebXml>
             <!-- Add a few custom attributes to the manifest -->          


### PR DESCRIPTION
Hit a few bumps on the road when R&D-ing with various Java versions. This fixes what I encountered so far.